### PR TITLE
2-step deposit mechanics with queue exits

### DIFF
--- a/RPIPs/RPIP-42.md
+++ b/RPIPs/RPIP-42.md
@@ -92,8 +92,8 @@ ETH from the deposit pool SHALL be matched with validator deposits from queues a
 
 #### Initial Settings
 - The initial settings SHALL be:
-- `scrub_period`: 12 hours
-- `time_before_dissolve`: 2 weeks
+  - `scrub_period`: 12 hours
+  - `time_before_dissolve`: 2 weeks
 
 ## Specification taking effect with Saturn 2
 - Update `reduced_bond` to 1.5 ETH


### PR DESCRIPTION
- only requries two transactions from the node operator
- no reserving or bookkeeping in the deposit pool
- allows exiting of queue up until ETH is available for the validator to start staking

note that `deposit` assigning implies that if enough ETH is available, prestake will happen in the `deposit` transaction.