### PR TITLE
Various small polishing tweaks

### DIFF
--- a/RPIPs/RPIP-42.md
+++ b/RPIPs/RPIP-42.md
@@ -16,14 +16,14 @@ tags: tokenomics-2024, tokenomics-content
 ## Abstract
 This proposal dramatically increases the LTV used in the protocol (loan to value; the amount of ETH that can be borrowed per unit of bonded ETH). It does this safely by:
 - Enabling megapool-level penalties to mitigate/discourage MEV theft
-- Using forced exits as needed
+- Using forced exits as needed (see the required [RPIP-44](./RPIP-44.md))
 - Starting with lower LTV at lower total bonded ETH to mitigate/discourage MEV theft
 - Retaining sufficient bond per validator regardless of total stake to mitigate against slashing and abandonment
 - Providing increased capital efficiency with greater bond to encourage a node operator to stake as large nodes instead of many small nodes
 
 This proposal also explicitly tries to benefit the smallest node operators in a few ways, in line with the pDAO charter values of decentralization and prioritizing Ethereum health (see [RPIP-23](./RPIP-23.md)):
 - We willingly take on somewhat more MEV-theft risk for the smallest node operators (see [Rationale](#rationale))
-- We give precedence to small nodes staking some number of initial validators in the Node Operator queue (see [RPIP-59](./RPIP-59.md))
+- We give precedence to small nodes staking some number of initial validators in the Node Operator queue (see proposed [RPIP-59](./RPIP-59.md))
 - There is a small but tangible financial benefit for large stakers that stake as few large nodes instead of many small nodes -- this (alongside our vote power, which scales with the square root of vote-eligible RPL) helps preserve the strong governance voice of small node operators
 
 ## Motivation
@@ -80,8 +80,6 @@ This portion of the RPIP SHALL be considered Living. It may be updated by a DAO 
 |-----------|----------------------|------------|------------|
 | MEV theft | theft size + 0.2 ETH | 2024-03-29 | 2024-03-29 |
 
-## Implementation thoughts
-When showing legacy node status, there is not a trivial way to get the node index for a given address. That said, the other direction is trivial using `RocketNodeManager.getNodeAt`, so the work can get moved off-chain. Eg, one can iterate across all possible node indices and then pass in the node index that matches the node's address; the smart contract can confirm the match to demonstrate legacy node status.
 
 ## Rationale
 The bond curve is an attempt to get close to maximizing capital efficiency while maintaining safety. It balances capital efficiency with slashing, leakage, and MEV theft risks as described in [Security considerations](#security-considerations). 

--- a/RPIPs/RPIP-44.md
+++ b/RPIPs/RPIP-44.md
@@ -9,12 +9,12 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-05
-requires: 42, 43, eip-7002
+requires: 43, eip-7002
 tags: tokenomics-2024, tokenomics-content
 ---
 
 ## Abstract
-This proposal specifies when [execution layer triggerable exits as defined in EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) will be used by Rocket Pool contracts. There are two enumerated use cases. The first is that the node operator may freely request exits of their validators. The second is a keeper mechanism that allows and incentivizes any user to forcibly exit a node operator's validators if that node operator owes the protocol a threshold amount. This helps keep rETH performant and minimizes funds lost to theft.
+This proposal specifies when [execution layer triggerable exits as defined in EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) will be used by Rocket Pool contracts. There are two enumerated use cases. The first is that the node operator may freely request exits of their validators. The second is a mechanism that allows any user to forcibly exit a node operator's validators if that node operator owes the protocol a threshold amount. This helps keep rETH performant and minimizes funds lost to theft.
 
 There is at least one additional use case not addressed in this RPIP, which is to exit badly-performing (eg, abandoned) validators. It is likely the pDAO will wish to supersede this RPIP to include that functionality. However, as it requires modeling and is not a critical component of the tokenomics rework, it is not being addressed at this time. For similar reasons, this RPIP does not include a keeper-based design to reward those that trigger forced exits. Please see a [historical version of RPIP-44](https://github.com/rocket-pool/RPIPs/blob/09d445accaa77f355acae1e943910ad0229a1d2e/RPIPs/RPIP-44.md) for initial but incomplete ideas to address abandonment and a keeper network.
 

--- a/RPIPs/RPIP-49.md
+++ b/RPIPs/RPIP-49.md
@@ -128,11 +128,12 @@ The tokenomics rework package will likely be split between two protocol upgrades
 * RPL Value Capture based on vote outcome - [RPL Burn](RPIP-45.md) / [RPL Buy & LP](RPIP-50.md) / Increased share to vote-eligible RPL staked in megapools
 
 ## Current Status
-Last Updated: July 16th
+Last Updated: July 24th
 
 Current efforts are primarily focused on:
-1. Confirming the Core Team is happy with RPIP specification contents and making minor adjustments as needed.
-2. Polishing the RPIP specifications ready for vote.
+1. Polishing the RPIP specifications for vote.
+2. Forum temperature check and associated discussion.
+3. Preparing vote text for vote.
 
 A maintained list of open tasks is available via Google sheet [here](https://docs.google.com/spreadsheets/d/1KDTeFnNl3XLFO37upti6NbT2p2GDYJ4GKH4aJ51gQZA/edit?pli=1#gid=725857744). 
 
@@ -155,8 +156,8 @@ The below is generally agreed to be the steps to be completed before we can cons
 2. **Done** - Seek feedback from technically skilled or highly engaged community members on the draft specifications. 
 3. **Done** - Create high-level explanations and informational material for the full proposal for consumption by the wider community.
 4. **Done** - Make a concerted effort to gather feedback via the forum from the wider community.
-5. **Active** - Update the proposal and specifications as needed taking into account wider community feedback.
-6. Run a forum temperature check vote on the rework package (bar the 'still-to-ratify' list above).
+5. **Done** - Update the proposal and specifications as needed taking into account wider community feedback.
+6. **Active** Run a forum temperature check vote on the rework package (bar the 'still-to-ratify' list above).
 7. Run a snapshot vote on the rework package as Living RPIPs, acknowledging the existence of the 'still-to-ratify' list above.
 8. Run one or more snapshot vote(s) as blockers are cleared from the 'still-to-ratify' list. The end state will include no remaining blockers and the status of the rework RPIPs set to Final.
 
@@ -172,7 +173,7 @@ The below components have been discussed, but are not currently considered high 
 * A [tokenomics Q&A video](https://www.youtube.com/watch?v=p-Q6fQsVBTY), kindly hosted by the Rocket Fuel podcast.
 
 ## Acknowledgements
-The tokenomics package is based on the [early-March proposal from Valdorff](../assets/rpip-49/readme.md). The initial drafts have seen a significant improvement as a result of discussions with many people (thanks to 🏆samus🏆, 🏆sckuzzle, 🏆epineph, 🏆LongForWisdom, 🏆knoshua, uisce, langers, NonFungibleYokem, MountainB, luominx, ArtDemocrat, and many others). 
+The tokenomics package is based on the [early-March proposal from Valdorff](../assets/rpip-49/readme.md). The initial drafts have seen a significant improvement as a result of discussions with many people (thanks to 🏆samus🏆, 🏆sckuzzle, 🏆epineph, 🏆LongForWisdom, 🏆knoshua, ramana, uisce, langers, NonFungibleYokem, MountainB, luominx, ArtDemocrat, and many others). 
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/RPIPs/RPIP-59.md
+++ b/RPIPs/RPIP-59.md
@@ -9,7 +9,7 @@ status: Draft
 type: Protocol
 category: Core
 created: 2024-03-08
-requires: 42, 43, 44
+requires: 43, 44
 tags: tokenomics-2024, tokenomics-content
 ---
 

--- a/tokenomics-explainers/001-why-rework.md
+++ b/tokenomics-explainers/001-why-rework.md
@@ -54,8 +54,7 @@ RPL value change dominates rewards, and given the volatility in crypto, this is 
 Figure 1 below shows that many node operators simply opt out of topping off their RPL stake.  
   
 Further, the metric used for the RPL reward threshold is "RPL staked as a percentage of borrowed ETH", which means there are two ways to requalify for rewards. Top up to increase staked RPL, or exit minipools to reduce borrowed ETH. Some node operators have opted for the second option.
-  
-TODO -- update to more recent state
+
 <img src="../assets/tokenomics-explainers/001-figure-1.png" alt="Figure 1" width="1000px"></br>
 _Figure 1 - Rocket Pool Minipool Collateralization - [Source](https://harpocryptes.github.io/)_
   

--- a/tokenomics-explainers/003-rework-foundation.md
+++ b/tokenomics-explainers/003-rework-foundation.md
@@ -92,7 +92,7 @@ In this case study, we have 3 node operators (NOs). (A) has 8 ETH and no RPL sta
 <img src="../assets/tokenomics-explainers/003-figure-6.png" alt="Figure 6" width="1000px"></br>
 _Figure 6 - Case Study ETH-Only Growth Sankey Diagram_
 
-Now we see 9 more NOs identical to (A) join. As you can see, there’s a self-balancing effect. Voter Share value paid to NO B and C increased 4x even though they have the same RPL.	Surplus Share value increased 4x over the same supply of RPL. In short: node operators unwilling to take on RPL exposure still grow the protocol’s ability to meet rETH demand, and higher rETH supply makes RPL exposure more attractive.
+Now we see 9 more NOs identical to (A) join. As you can see, there’s a self-balancing effect. Voter Share increased 4x while the amount of staked RPL stayed the same. As a result, NO B and C earn 4x more from Voter Share (even though they have the same RPL). In short: node operators unwilling to take on RPL exposure still grow the protocol’s ability to meet rETH demand, and higher rETH supply makes RPL exposure more attractive.
 
 ## Lower Bonds and Capital Efficiency
 Zooming _all_ the way out, the total revenue is `reth_commision*reth_tvl_in_validators`. To get total ROI, we divide that by total investment, which is `(bonded_eth + rpl_mcap_in_eth)`. From this we can see that there are 4 ways for total ROI to improve if all else is held equal: (1) increased rETH commission, (2) increased rETH supply, (3) less bonded ETH, and (4) lower RPL market cap. Lower bonds are important because they are the only way to execute on (3) without decreasing rETH supply. In fact, lower bonds also help hit (2) by making it possible to service more rETH supply given the same node operator investment.


### PR DESCRIPTION
- Remove the RPIP-42 requirement from RPIP-44 and RPIP-59
- RPIP-42's abstract talked beyond the RPIP itself, clarified that slightly
- Remove vestigial reference to keeper network from RPIP-44
- Add ramana to RPIP-49 acknowledgements
- Update RPIP-49 to latest status
- Remove TODO comment from a tokenomics-explainer 001
- Correct a "Surplus Share" mention to "Voter Share" in tokenomics-explainer 003